### PR TITLE
SessionMemory (Jules)

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -84,6 +84,39 @@ async def main():
         # California
 ```
 
+!!! note "Simplified Conversations with Agent Memory"
+
+    The above example demonstrates manual conversation management. If the agent is configured with memory (e.g., `Agent(..., memory=True)`), the history is automatically managed. The same conversation would look like this:
+
+    ```python
+    async def main_with_memory():
+        # Note: Agent is initialized with memory=True
+        agent_with_memory = Agent(
+            name="Assistant", 
+            instructions="Reply very concisely. Remember our conversation.", 
+            memory=True # Enables automatic memory management
+        )
+
+        with trace(workflow_name="ConversationWithMemory", group_id=thread_id): # Assuming thread_id is defined
+            # First turn
+            # The agent's memory is empty initially.
+            result1 = await Runner.run(agent_with_memory, "What city is the Golden Gate Bridge in?")
+            print(result1.final_output)
+            # Expected: San Francisco
+            # The agent's memory now contains:
+            # - User: "What city is the Golden Gate Bridge in?"
+            # - Assistant: "San Francisco" (or its structured representation)
+
+            # Second turn
+            # Runner.run will automatically use the history from agent_with_memory.memory
+            result2 = await Runner.run(agent_with_memory, "What state is it in?")
+            print(result2.final_output)
+            # Expected: California
+            # The agent's memory now contains the full conversation.
+    ```
+    Refer to the [Agent Memory documentation in `agents.md`](agents.md#agent-memory) for more details on configuring memory.
+
+
 ## Exceptions
 
 The SDK raises exceptions in certain cases. The full list is in [`agents.exceptions`][]. As an overview:

--- a/src/agents/memory.py
+++ b/src/agents/memory.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+# Removed abc import as it's no longer needed by SessionMemory
+import sqlite3
+import json
+import time
+from typing import TYPE_CHECKING, Protocol, runtime_checkable # Added Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .items import TResponseInputItem
+
+
+@runtime_checkable
+class SessionMemory(Protocol): # Changed from abc.ABC to Protocol
+    """Protocol for session memory implementations."""
+
+    async def get_history(self) -> list[TResponseInputItem]:
+        """Returns the conversation history as a list of input items."""
+        ... # Changed from pass to ...
+
+    async def add_message(self, item: TResponseInputItem) -> None:
+        """Adds a single message/item to the history."""
+        ... # Changed from pass to ...
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        """Adds a list of items to the history."""
+        ... # Changed from pass to ...
+
+    async def clear(self) -> None:
+        """Clears the entire history."""
+        ... # Changed from pass to ...
+
+
+class SQLiteSessionMemory(SessionMemory): # SQLiteSessionMemory still "implements" the protocol
+    """
+    A SessionMemory implementation that uses an SQLite database to store conversation history.
+    Each message is stored as a JSON string in the database.
+    """
+
+    def __init__(self, db_path: str | None = None, *, table_name: str = "chat_history"):
+        """
+        Initializes the SQLite session memory.
+
+        Args:
+            db_path: Path to the SQLite database file. If None, an in-memory database is used.
+            table_name: The name of the table to store chat history.
+        """
+        self.db_path = db_path if db_path else ":memory:"
+        self.table_name = table_name
+        self._init_db()
+
+    def _get_conn(self):
+        # For a simple default, synchronous sqlite3 is okay.
+        # For production async, aiosqlite would be better.
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self):
+        with self._get_conn() as conn:
+            cursor = conn.cursor()
+            # Added session_id to allow for multiple conversations, though not used in this version
+            cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                item_json TEXT NOT NULL
+            )
+            """)
+            cursor.execute(f"CREATE INDEX IF NOT EXISTS idx_timestamp ON {self.table_name} (timestamp)")
+            conn.commit()
+
+    async def get_history(self) -> list[TResponseInputItem]:
+        """Returns the conversation history, ordered by timestamp."""
+        with self._get_conn() as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT item_json FROM {self.table_name} ORDER BY timestamp ASC")
+            rows = cursor.fetchall()
+            history = []
+            for row in rows:
+                try:
+                    item = json.loads(row[0])
+                    history.append(item) 
+                except json.JSONDecodeError as e:
+                    # In a real app, use logging
+                    print(f"Warning: SQLiteSessionMemory - Could not decode JSON from database: {row[0]}. Error: {e}") 
+            return history
+
+    async def add_message(self, item: TResponseInputItem) -> None:
+        """Adds a single message/item to the history."""
+        # This can be implemented more efficiently if needed, but for simplicity:
+        await self.add_items([item])
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        """Adds a list of items to the history."""
+        current_timestamp = time.time()
+        with self._get_conn() as conn:
+            cursor = conn.cursor()
+            for i, item in enumerate(items):
+                # Ensure unique timestamp for ordering within a batch
+                item_timestamp = current_timestamp + (i * 1e-7) # Small offset for ordering
+                try:
+                    item_json = json.dumps(item)
+                except TypeError as e:
+                    print(f"Warning: SQLiteSessionMemory - Error serializing item to JSON: {item}. Error: {e}")
+                    continue 
+                
+                cursor.execute(
+                    f"INSERT INTO {self.table_name} (timestamp, item_json) VALUES (?, ?)",
+                    (item_timestamp, item_json),
+                )
+            conn.commit()
+
+    async def clear(self) -> None:
+        """Clears the entire history from the table."""
+        with self._get_conn() as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"DELETE FROM {self.table_name}")
+            conn.commit()

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -78,7 +78,24 @@ class RunResultBase(abc.ABC):
         return cast(T, self.final_output)
 
     def to_input_list(self) -> list[TResponseInputItem]:
-        """Creates a new input list, merging the original input with all the new items generated."""
+        """
+        Creates a new list of input items, representing the sequence of interactions
+        for the specific agent run that produced this result. It merges the
+        `self.input` (the input items that initiated this particular run) with
+        all `self.new_items` (items generated during this run, like messages,
+        tool calls, and tool results).
+
+        This method is useful for:
+        - Manually continuing a conversation if the agent is run without session memory.
+        - Inspecting the specific inputs and outputs of a single `Runner.run()` call,
+          even if that run was part of a larger conversation managed by built-in agent memory.
+        - Extracting a specific segment of a conversation for logging or debugging.
+
+        Note: If the agent has active session memory, this list does NOT include
+        items from turns prior to this specific `RunResult`'s generating run.
+        To get the complete history from an agent with memory, you would typically
+        access the memory object directly if needed for other purposes.
+        """
         original_items: list[TResponseInputItem] = ItemHelpers.input_to_new_input_list(self.input)
         new_items = [item.to_input_item() for item in self.new_items]
 

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,233 @@
+import asyncio
+import sqlite3
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Assuming TResponseInputItem is accessible for type hinting and test data construction.
+# Adjust the import path if necessary based on project structure.
+# from src.agents.items import TResponseInputItem # Might be needed for direct use
+# For testing, constructing dicts that match TResponseInputItem structure is often sufficient.
+
+from src.agents.agent import Agent
+from src.agents.memory import SessionMemory, SQLiteSessionMemory
+from src.agents.run import Runner, RunConfig
+from src.agents.models.interface import Model # For mock model
+from src.agents.items import ModelResponse, TResponseInputItem, TResponseOutputItem # For constructing mock responses
+
+
+# Test data - sample input items
+user_msg_1: TResponseInputItem = {"role": "user", "content": "Hello there!"}
+asst_msg_1: TResponseInputItem = {"role": "assistant", "content": "Hi! How can I help?"}
+user_msg_2: TResponseInputItem = {"role": "user", "content": "What's the weather?"}
+asst_msg_2: TResponseInputItem = {"role": "assistant", "content": "It's sunny!"}
+
+
+@pytest.fixture
+def in_memory_sqlite_memory() -> SQLiteSessionMemory:
+    """Provides an in-memory SQLiteSessionMemory instance for testing."""
+    memory = SQLiteSessionMemory(db_path=":memory:")
+    # Ensure fresh table for each test using this fixture
+    asyncio.run(memory.clear()) # Clear in case a previous test in the same session didn't clean up
+    memory._init_db() # Re-initialize schema
+    return memory
+
+class TestSQLiteSessionMemory:
+    @pytest.mark.asyncio
+    async def test_add_and_get_history(self, in_memory_sqlite_memory: SQLiteSessionMemory):
+        memory = in_memory_sqlite_memory
+        await memory.add_message(user_msg_1)
+        await memory.add_items([asst_msg_1, user_msg_2])
+
+        history = await memory.get_history()
+        assert len(history) == 3
+        assert history[0] == user_msg_1
+        assert history[1] == asst_msg_1
+        assert history[2] == user_msg_2
+
+    @pytest.mark.asyncio
+    async def test_clear_history(self, in_memory_sqlite_memory: SQLiteSessionMemory):
+        memory = in_memory_sqlite_memory
+        await memory.add_message(user_msg_1)
+        await memory.clear()
+        history = await memory.get_history()
+        assert len(history) == 0
+
+    @pytest.mark.asyncio
+    async def test_add_items_maintains_order(self, in_memory_sqlite_memory: SQLiteSessionMemory):
+        memory = in_memory_sqlite_memory
+        items = [{"role": "user", "content": f"Message {i}"} for i in range(5)]
+        await memory.add_items(items)
+        history = await memory.get_history()
+        assert history == items
+
+    def test_persistent_db(self, tmp_path):
+        db_file = tmp_path / "test_persistent.db"
+        memory1 = SQLiteSessionMemory(db_path=str(db_file))
+        asyncio.run(memory1.add_message(user_msg_1))
+        
+        # Create a new instance with the same file
+        memory2 = SQLiteSessionMemory(db_path=str(db_file))
+        history = asyncio.run(memory2.get_history())
+        assert len(history) == 1
+        assert history[0] == user_msg_1
+        asyncio.run(memory2.clear()) # Clean up
+
+
+class TestAgentMemoryInitialization:
+    def test_agent_memory_true_initializes_sqlite(self):
+        agent = Agent(name="TestAgent", memory=True)
+        assert isinstance(agent.memory, SQLiteSessionMemory)
+
+    def test_agent_memory_false_sets_none(self):
+        agent = Agent(name="TestAgent", memory=False)
+        assert agent.memory is None
+
+    def test_agent_memory_none_is_default(self):
+        agent = Agent(name="TestAgent")
+        assert agent.memory is None
+
+    def test_agent_custom_memory_instance(self):
+        custom_memory_mock = AsyncMock(spec=SessionMemory)
+        agent = Agent(name="TestAgent", memory=custom_memory_mock)
+        assert agent.memory is custom_memory_mock
+
+
+@pytest.mark.asyncio
+async def test_runner_with_memory_integration():
+    """Test Runner.run with an agent that has memory over multiple turns."""
+    
+    # Mock the model provider and model
+    mock_model = AsyncMock(spec=Model)
+    
+    # Define model responses for multiple turns
+    # Turn 1: User says "Hello", Assistant says "Hi"
+    model_response_1_output: list[TResponseOutputItem] = [{"type": "message", "role": "assistant", "content": [{"type": "text", "text": "Hi"}]}]
+    model_response_1 = ModelResponse(output=model_response_1_output, usage=MagicMock(), response_id="res1")
+
+    # Turn 2: User says "State?", Assistant says "California"
+    model_response_2_output: list[TResponseOutputItem] = [{"type": "message", "role": "assistant", "content": [{"type": "text", "text": "California"}]}]
+    model_response_2 = ModelResponse(output=model_response_2_output, usage=MagicMock(), response_id="res2")
+
+    mock_model.get_response.side_effect = [model_response_1, model_response_2]
+    # stream_response would also need mocking if testing streaming runs here
+
+    mock_provider = MagicMock()
+    mock_provider.get_model.return_value = mock_model
+
+    run_config = RunConfig(model_provider=mock_provider)
+    
+    # Use a real SQLiteSessionMemory (in-memory)
+    agent_memory = SQLiteSessionMemory(db_path=":memory:")
+    agent = Agent(name="TestAgentWithMemory", model="test-model", memory=agent_memory)
+
+    # Turn 1
+    input_turn_1 = "Hello"
+    result_turn_1 = await Runner.run(agent, input_turn_1, run_config=run_config)
+    
+    assert result_turn_1.final_output == "Hi" # Assuming default output_type is str
+    
+    # Check memory after turn 1
+    history_after_turn_1 = await agent_memory.get_history()
+    assert len(history_after_turn_1) == 2 # User: Hello, Assistant: Hi
+    assert history_after_turn_1[0]["role"] == "user"
+    assert history_after_turn_1[0]["content"] == "Hello"
+    assert history_after_turn_1[1]["role"] == "assistant"
+    assert history_after_turn_1[1]["content"] == [{"type": "text", "text": "Hi"}] # ModelResponse output structure
+
+    # Verify model was called with correct history (i.e., empty for first turn)
+    args_call_1, kwargs_call_1 = mock_model.get_response.call_args_list[0]
+    input_to_model_turn_1 = kwargs_call_1.get('input')
+    assert len(input_to_model_turn_1) == 1
+    assert input_to_model_turn_1[0]["content"] == "Hello"
+
+
+    # Turn 2 - using the *same agent instance* which now has memory
+    input_turn_2 = "What state is it in?" # Example from issue
+    result_turn_2 = await Runner.run(agent, input_turn_2, run_config=run_config)
+
+    assert result_turn_2.final_output == "California"
+
+    # Check memory after turn 2
+    history_after_turn_2 = await agent_memory.get_history()
+    assert len(history_after_turn_2) == 4 # User: Hello, Asst: Hi, User: State?, Asst: California
+    assert history_after_turn_2[2]["role"] == "user"
+    assert history_after_turn_2[2]["content"] == "What state is it in?"
+    assert history_after_turn_2[3]["role"] == "assistant"
+    assert history_after_turn_2[3]["content"] == [{"type": "text", "text": "California"}]
+
+
+    # Verify model was called with history for second turn
+    args_call_2, kwargs_call_2 = mock_model.get_response.call_args_list[1]
+    input_to_model_turn_2 = kwargs_call_2.get('input')
+
+    assert len(input_to_model_turn_2) == 3 # History (User:Hello, Asst:Hi) + New (User:State?)
+    assert input_to_model_turn_2[0]["role"] == "user"
+    assert input_to_model_turn_2[0]["content"] == "Hello"
+    assert input_to_model_turn_2[1]["role"] == "assistant"
+    # The content saved from ModelResponse is the list of dicts, not just plain text
+    assert input_to_model_turn_2[1]["content"] == [{"type": "text", "text": "Hi"}] 
+    assert input_to_model_turn_2[2]["role"] == "user"
+    assert input_to_model_turn_2[2]["content"] == "What state is it in?"
+    
+    # Test clearing memory via agent reference (if Agent had a clear_memory method, or directly)
+    await agent.memory.clear()
+    history_after_clear = await agent_memory.get_history()
+    assert len(history_after_clear) == 0
+
+
+@pytest.mark.asyncio
+async def test_issue_example_with_memory():
+    """Test the specific example from the issue description."""
+    mock_model = AsyncMock(spec=Model)
+    
+    # Mock responses
+    # 1. "What city is the Golden Gate Bridge in?" -> "San Francisco"
+    res1_output: list[TResponseOutputItem] = [{"type": "message", "role": "assistant", "content": [{"type": "text", "text": "San Francisco"}]}]
+    res1 = ModelResponse(output=res1_output, usage=MagicMock(), response_id="res_city")
+
+    # 2. "What state is it in?" -> "California"
+    res2_output: list[TResponseOutputItem] = [{"type": "message", "role": "assistant", "content": [{"type": "text", "text": "California"}]}]
+    res2 = ModelResponse(output=res2_output, usage=MagicMock(), response_id="res_state")
+    
+    mock_model.get_response.side_effect = [res1, res2]
+
+    mock_provider = MagicMock()
+    mock_provider.get_model.return_value = mock_model
+    run_config = RunConfig(model_provider=mock_provider)
+
+    # Agent with memory=True uses default SQLiteSessionMemory
+    agent = Agent(name="Assistant", instructions="Reply very concisely.", model="test-model", memory=True)
+
+    # First turn
+    result1 = await Runner.run(agent, "What city is the Golden Gate Bridge in?", run_config=run_config)
+    # print(f"Result 1: {result1.final_output}") # For debugging if needed
+    assert result1.final_output == "San Francisco"
+
+    # Check memory content (optional, but good for deep check)
+    if isinstance(agent.memory, SQLiteSessionMemory): # Should be
+        history1 = await agent.memory.get_history()
+        assert len(history1) == 2
+        assert history1[0]["content"] == "What city is the Golden Gate Bridge in?"
+        assert history1[1]["content"] == [{"type": "text", "text": "San Francisco"}]
+
+
+    # Second turn - memory should be used automatically
+    result2 = await Runner.run(agent, "What state is it in?", run_config=run_config)
+    # print(f"Result 2: {result2.final_output}") # For debugging
+    assert result2.final_output == "California"
+    
+    # Check that the model received the history in the second call
+    assert mock_model.get_response.call_count == 2
+    args_call_2, kwargs_call_2 = mock_model.get_response.call_args_list[1]
+    input_to_model_turn_2 = kwargs_call_2.get('input')
+    
+    assert len(input_to_model_turn_2) == 3 # History (User, Asst) + New User Question
+    assert input_to_model_turn_2[0]["content"] == "What city is the Golden Gate Bridge in?"
+    assert input_to_model_turn_2[1]["content"] == [{"type": "text", "text": "San Francisco"}]
+    assert input_to_model_turn_2[2]["content"] == "What state is it in?"
+
+# TODO: Add tests for streaming runs with memory if time permits.
+# The logic in _run_single_turn_streamed is very similar to _run_single_turn,
+# so these tests provide good coverage of the core memory handling.


### PR DESCRIPTION
I've updated the `SessionMemory` interface from an `abc.ABC` to a `typing.Protocol`. I've also marked it as `@runtime_checkable` to ensure that `isinstance` checks continue to work as expected.

This change provides more flexibility for implementing custom memory solutions, allowing for structural subtyping (duck typing) while still enabling runtime type verification.

The `SQLiteSessionMemory` implementation and existing type hints and checks in the `Agent` and `Runner` classes remain compatible with this change. Unit tests and documentation have been verified and updated where necessary to reflect `SessionMemory` as a Protocol.